### PR TITLE
Added the getEnumStringPredicate method for building predicates 

### DIFF
--- a/service/src/main/java/greencity/filters/CustomSpecification.java
+++ b/service/src/main/java/greencity/filters/CustomSpecification.java
@@ -11,13 +11,13 @@ public interface CustomSpecification<T> extends Specification<T> {
      * Used for build predicate for id filter.
      */
     default Predicate getIdPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-                                     SearchCriteria searchCriteria) {
+        SearchCriteria searchCriteria) {
         try {
             return criteriaBuilder
-                    .equal(root.get(searchCriteria.getKey()), searchCriteria.getValue());
+                .equal(root.get(searchCriteria.getKey()), searchCriteria.getValue());
         } catch (NumberFormatException ex) {
             return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-                    : criteriaBuilder.disjunction();
+                : criteriaBuilder.disjunction();
         }
     }
 
@@ -25,9 +25,9 @@ public interface CustomSpecification<T> extends Specification<T> {
      * Used for build predicate for string fields filter.
      */
     default Predicate getStringPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-                                         SearchCriteria searchCriteria) {
+        SearchCriteria searchCriteria) {
         return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-                : criteriaBuilder.like(root.get(searchCriteria.getKey()),
+            : criteriaBuilder.like(root.get(searchCriteria.getKey()),
                 "%" + searchCriteria.getValue() + "%");
     }
 
@@ -35,9 +35,9 @@ public interface CustomSpecification<T> extends Specification<T> {
      * Used for build predicate for status filter.
      */
     default Predicate getEnumPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-                                       SearchCriteria searchCriteria) {
+        SearchCriteria searchCriteria) {
         return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-                : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(Integer.class),
+            : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(Integer.class),
                 searchCriteria.getValue());
     }
 
@@ -45,9 +45,9 @@ public interface CustomSpecification<T> extends Specification<T> {
      * Used for build predicate for role filter.
      */
     default Predicate getEnumStringPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-                                             SearchCriteria searchCriteria) {
+        SearchCriteria searchCriteria) {
         return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-                : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(String.class),
+            : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(String.class),
                 searchCriteria.getValue());
     }
 }

--- a/service/src/main/java/greencity/filters/CustomSpecification.java
+++ b/service/src/main/java/greencity/filters/CustomSpecification.java
@@ -11,13 +11,13 @@ public interface CustomSpecification<T> extends Specification<T> {
      * Used for build predicate for id filter.
      */
     default Predicate getIdPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-        SearchCriteria searchCriteria) {
+                                     SearchCriteria searchCriteria) {
         try {
             return criteriaBuilder
-                .equal(root.get(searchCriteria.getKey()), searchCriteria.getValue());
+                    .equal(root.get(searchCriteria.getKey()), searchCriteria.getValue());
         } catch (NumberFormatException ex) {
             return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-                : criteriaBuilder.disjunction();
+                    : criteriaBuilder.disjunction();
         }
     }
 
@@ -25,19 +25,29 @@ public interface CustomSpecification<T> extends Specification<T> {
      * Used for build predicate for string fields filter.
      */
     default Predicate getStringPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-        SearchCriteria searchCriteria) {
+                                         SearchCriteria searchCriteria) {
         return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-            : criteriaBuilder.like(root.get(searchCriteria.getKey()),
+                : criteriaBuilder.like(root.get(searchCriteria.getKey()),
                 "%" + searchCriteria.getValue() + "%");
     }
 
     /**
-     * Used for build predicate for role and status filter.
+     * Used for build predicate for status filter.
      */
     default Predicate getEnumPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
-        SearchCriteria searchCriteria) {
+                                       SearchCriteria searchCriteria) {
         return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-            : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(Integer.class),
+                : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(Integer.class),
+                searchCriteria.getValue());
+    }
+
+    /**
+     * Used for build predicate for role filter.
+     */
+    default Predicate getEnumStringPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
+                                             SearchCriteria searchCriteria) {
+        return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
+                : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(String.class),
                 searchCriteria.getValue());
     }
 }

--- a/service/src/main/java/greencity/filters/UserSpecification.java
+++ b/service/src/main/java/greencity/filters/UserSpecification.java
@@ -34,7 +34,7 @@ public class UserSpecification implements CustomSpecification<User> {
             }
             if (searchCriteria.getType().equals("role")) {
                 allPredicate =
-                    criteriaBuilder.and(allPredicate, getEnumPredicate(root, criteriaBuilder, searchCriteria));
+                    criteriaBuilder.and(allPredicate, getEnumStringPredicate(root, criteriaBuilder, searchCriteria));
             }
             if (searchCriteria.getType().equals("userStatus")) {
                 allPredicate =


### PR DESCRIPTION
 Dear colleagues,

 With this fix, we've restored the ability to search for users based on individual criteria or any combination of these criteria.
 Please be aware that when specifying 'userStatus', it should be expressed as a numerical value.

Your feedback is highly appreciated.

 
 Issue #291